### PR TITLE
Drf 3.0: Python 2.6 and 3.x Compatibility

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,7 @@ branches:
 
 # command to install requirements
 install:
+  - if [[ $TRAVIS_PYTHON_VERSION == 2.6 ]]; then pip install ordereddict; fi
   - pip install $DJANGO
   - pip install -r requirements-test.txt
   - python setup.py -q install

--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -11,6 +11,11 @@ except ImportError:
 
 from .fields import GeometryField
 
+_geo_field_mapping = ModelSerializer._field_mapping.mapping
+_geo_field_mapping.update({
+    django_GeometryField: GeometryField
+})
+
 
 class GeoModelSerializer(ModelSerializer):
     """
@@ -18,9 +23,7 @@ class GeoModelSerializer(ModelSerializer):
     for GeoDjango fields to be serialized as GeoJSON
     compatible data
     """
-    _field_mapping = ClassLookupDict(dict(ModelSerializer._field_mapping.mapping.items() + {
-        django_GeometryField: GeometryField
-    }.items()))
+    _field_mapping = ClassLookupDict(_geo_field_mapping)
 
 
 class GeoFeatureModelListSerializer(ListSerializer):

--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -1,9 +1,13 @@
-from collections import OrderedDict
 from django.core.exceptions import ImproperlyConfigured
 from django.contrib.gis.db.models.fields import GeometryField as django_GeometryField
 
 from rest_framework.serializers import ModelSerializer, ListSerializer, LIST_SERIALIZER_KWARGS
 from rest_framework.utils.field_mapping import ClassLookupDict
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    from ordereddict import OrderedDict
 
 from .fields import GeometryField
 


### PR DESCRIPTION
This commit adds Python 2.6 and 3.x compatibility.

As discussed in pull #34, I am recreating this pull request with 2 clean commits. As before, all tests are passing.