### PR TITLE
Support partial modifications without geometries when using the GeoFeatureModelSerializer. Fixes issue #51

### DIFF
--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -120,13 +120,15 @@ class GeoFeatureModelSerializer(GeoModelSerializer):
             features = data['features']
             for feature in features:
                 _dict = feature["properties"]
-                geom = { self.Meta.geo_field: feature["geometry"] }
-                _dict.update(geom)
+                if 'geometry' in feature:
+                    geom = { self.Meta.geo_field: feature["geometry"] }
+                    _dict.update(geom)
                 _unformatted_data.append(_dict)
         elif 'properties' in data:
             _dict = data["properties"]
-            geom = { self.Meta.geo_field: data["geometry"] }
-            _dict.update(geom)
+            if 'geometry' in data:
+                geom = { self.Meta.geo_field: data["geometry"] }
+                _dict.update(geom)
             _unformatted_data = _dict
         else:
             _unformatted_data = data


### PR DESCRIPTION
I also stumbled about the problem mentioned in issue #51 that the GeoFeatureModelSerializer is not able to deserialize request which only contain a partial representation of the model without the geometry field. When no geometry is provided the serializer will currently raise a KeyError. This issue is crucial to support for example partial PATCH requests.

This pull request fixes #51 and also adds unittests for the expected behavior.