### PR TITLE
check explicitly for not None on field values

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,3 +3,4 @@ djangorestframework>=3.0.4
 coverage
 coveralls
 django-filter
+Pillow

--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -100,7 +100,7 @@ class GeoFeatureModelSerializer(GeoModelSerializer):
             if field.read_only and instance is None:
                 continue
             value = field.get_attribute(instance)
-            if value:
+            if value is not None:
                 value = field.to_representation(value)
             if self.Meta.id_field is not False and field_name == self.Meta.id_field:
                 ret["id"] = value

--- a/tests/django_restframework_gis_tests/models.py
+++ b/tests/django_restframework_gis_tests/models.py
@@ -34,7 +34,7 @@ class Location(models.Model):
 class LocatedFile(models.Model):
     name = models.CharField(max_length=32)
     slug = models.SlugField(max_length=128, unique=True, blank=True)
-    file = models.FileField(blank=True, null=True)
+    file = models.FileField(upload_to='located_files', blank=True, null=True)
     geometry = models.GeometryField()
 
     objects = models.GeoManager()
@@ -61,7 +61,7 @@ class LocatedFile(models.Model):
 class LocatedImage(models.Model):
     name = models.CharField(max_length=32)
     slug = models.SlugField(max_length=128, unique=True, blank=True)
-    image = models.ImageField(blank=True, null=True)
+    image = models.ImageField(upload_to='located_images', blank=True, null=True)
     geometry = models.GeometryField()
 
     objects = models.GeoManager()

--- a/tests/django_restframework_gis_tests/models.py
+++ b/tests/django_restframework_gis_tests/models.py
@@ -2,7 +2,7 @@ from django.contrib.gis.db import models
 from django.utils.text import slugify
 
 
-__all__ = ['Location']
+__all__ = ['Location', 'LocatedImage']
 
 
 class Location(models.Model):
@@ -29,3 +29,29 @@ class Location(models.Model):
     def save(self, *args, **kwargs):
         self._generate_slug()
         super(Location, self).save(*args, **kwargs)
+
+class LocatedImage(models.Model):
+    name = models.CharField(max_length=32)
+    slug = models.SlugField(max_length=128, unique=True, blank=True)
+    image = models.ImageField(blank=True, null=True)
+    geometry = models.GeometryField()
+
+    objects = models.GeoManager()
+
+    def __unicode__(self):
+        return self.name
+
+    def _generate_slug(self):
+        if self.slug == '' or self.slug is None:
+            try:
+                name = unicode(self.name)
+            except NameError:
+                name = self.name
+            self.slug = slugify(name)
+
+    def clean(self):
+        self._generate_slug()
+
+    def save(self, *args, **kwargs):
+        self._generate_slug()
+        super(LocatedImage, self).save(*args, **kwargs)

--- a/tests/django_restframework_gis_tests/models.py
+++ b/tests/django_restframework_gis_tests/models.py
@@ -2,7 +2,7 @@ from django.contrib.gis.db import models
 from django.utils.text import slugify
 
 
-__all__ = ['Location', 'LocatedImage']
+__all__ = ['Location', 'LocatedFile', 'LocatedImage']
 
 
 class Location(models.Model):
@@ -29,6 +29,34 @@ class Location(models.Model):
     def save(self, *args, **kwargs):
         self._generate_slug()
         super(Location, self).save(*args, **kwargs)
+
+
+class LocatedFile(models.Model):
+    name = models.CharField(max_length=32)
+    slug = models.SlugField(max_length=128, unique=True, blank=True)
+    file = models.FileField(blank=True, null=True)
+    geometry = models.GeometryField()
+
+    objects = models.GeoManager()
+
+    def __unicode__(self):
+        return self.name
+
+    def _generate_slug(self):
+        if self.slug == '' or self.slug is None:
+            try:
+                name = unicode(self.name)
+            except NameError:
+                name = self.name
+            self.slug = slugify(name)
+
+    def clean(self):
+        self._generate_slug()
+
+    def save(self, *args, **kwargs):
+        self._generate_slug()
+        super(LocatedFile, self).save(*args, **kwargs)
+
 
 class LocatedImage(models.Model):
     name = models.CharField(max_length=32)

--- a/tests/django_restframework_gis_tests/serializers.py
+++ b/tests/django_restframework_gis_tests/serializers.py
@@ -11,6 +11,7 @@ __all__ = [
     'LocationGeoFeatureSlugSerializer',
     'LocationGeoFeatureFalseIDSerializer',
     'PaginatedLocationGeoFeatureSerializer',
+    'LocatedFileGeoFeatureSerializer',
     'LocatedImageGeoFeatureSerializer',
 
 ]
@@ -73,8 +74,22 @@ class PaginatedLocationGeoFeatureSerializer(pagination.PageNumberPagination):
         object_serializer_class = LocationGeoFeatureSerializer
 
 
+class LocatedFileGeoFeatureSerializer(gis_serializers.GeoFeatureModelSerializer):
+    """ located file geo serializer  """
+    details = serializers.HyperlinkedIdentityField(view_name='api_geojson_located_file_details')
+    fancy_name = serializers.SerializerMethodField()
+    file = serializers.FileField(allow_empty_file=True)
+
+    def get_fancy_name(self, obj):
+        return u'Nice %s' % obj.name
+
+    class Meta:
+        model = Location
+        geo_field = 'geometry'
+
+
 class LocatedImageGeoFeatureSerializer(gis_serializers.GeoFeatureModelSerializer):
-    """ location geo serializer  """
+    """ located image geo serializer  """
     details = serializers.HyperlinkedIdentityField(view_name='api_geojson_located_image_details')
     fancy_name = serializers.SerializerMethodField()
     image = serializers.ImageField(allow_empty_file=True)

--- a/tests/django_restframework_gis_tests/serializers.py
+++ b/tests/django_restframework_gis_tests/serializers.py
@@ -11,6 +11,8 @@ __all__ = [
     'LocationGeoFeatureSlugSerializer',
     'LocationGeoFeatureFalseIDSerializer',
     'PaginatedLocationGeoFeatureSerializer',
+    'LocatedImageGeoFeatureSerializer',
+
 ]
 
 
@@ -69,3 +71,17 @@ class PaginatedLocationGeoFeatureSerializer(pagination.PageNumberPagination):
 
     class Meta:
         object_serializer_class = LocationGeoFeatureSerializer
+
+
+class LocatedImageGeoFeatureSerializer(gis_serializers.GeoFeatureModelSerializer):
+    """ location geo serializer  """
+    details = serializers.HyperlinkedIdentityField(view_name='api_geojson_located_image_details')
+    fancy_name = serializers.SerializerMethodField()
+    image = serializers.ImageField(allow_empty_file=True)
+
+    def get_fancy_name(self, obj):
+        return u'Fresh %s' % obj.name
+
+    class Meta:
+        model = Location
+        geo_field = 'geometry'

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -14,7 +14,7 @@ from django.test import TestCase
 from django.contrib.gis.geos import GEOSGeometry, Polygon, Point
 from django.core.urlresolvers import reverse
 
-from .models import Location, LocatedImage
+from .models import Location, LocatedFile, LocatedImage
 
 
 class TestRestFrameworkGis(TestCase):
@@ -273,6 +273,13 @@ class TestRestFrameworkGis(TestCase):
         response = self.client.get(url)
         with self.assertRaises(KeyError):
             response.data['id']
+
+    def test_geojson_filefield_attribute(self):
+        located_file = LocatedFile.objects.create(name='geojson filefield test', geometry='POINT (10.1 10.1)')
+
+        url = reverse('api_geojson_located_file_details', args=[located_file.id])
+        response = self.client.get(url)
+        self.assertEqual(response.data['properties']['file'], None)
 
     def test_geojson_imagefield_attribute(self):
         located_image = LocatedImage.objects.create(name='geojson imagefield test', geometry='POINT (10.1 10.1)')

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -14,7 +14,7 @@ from django.test import TestCase
 from django.contrib.gis.geos import GEOSGeometry, Polygon, Point
 from django.core.urlresolvers import reverse
 
-from .models import Location
+from .models import Location, LocatedImage
 
 
 class TestRestFrameworkGis(TestCase):
@@ -273,6 +273,13 @@ class TestRestFrameworkGis(TestCase):
         response = self.client.get(url)
         with self.assertRaises(KeyError):
             response.data['id']
+
+    def test_geojson_imagefield_attribute(self):
+        located_image = LocatedImage.objects.create(name='geojson imagefield test', geometry='POINT (10.1 10.1)')
+
+        url = reverse('api_geojson_located_image_details', args=[located_image.id])
+        response = self.client.get(url)
+        self.assertEqual(response.data['properties']['image'], None)
 
     def test_post_geojson_location_list(self):
         self.assertEqual(Location.objects.count(), 0)

--- a/tests/django_restframework_gis_tests/urls.py
+++ b/tests/django_restframework_gis_tests/urls.py
@@ -10,6 +10,7 @@ urlpatterns = patterns('django_restframework_gis_tests.views',
     url(r'^geojson/(?P<pk>[0-9]+)/$', 'geojson_location_details', name='api_geojson_location_details'),
     url(r'^geojson/(?P<slug>[-\w]+)/$', 'geojson_location_slug_details', name='api_geojson_location_slug_details'),
     url(r'^geojson-falseid/(?P<pk>[0-9]+)/$', 'geojson_location_falseid_details', name='api_geojson_location_falseid_details'),
+    url(r'^geojson-file/(?P<pk>[0-9]+)/$', 'geojson_located_file_details', name='api_geojson_located_file_details'),
     url(r'^geojson-image/(?P<pk>[0-9]+)/$', 'geojson_located_image_details', name='api_geojson_located_image_details'),
 
     # Filters

--- a/tests/django_restframework_gis_tests/urls.py
+++ b/tests/django_restframework_gis_tests/urls.py
@@ -10,7 +10,8 @@ urlpatterns = patterns('django_restframework_gis_tests.views',
     url(r'^geojson/(?P<pk>[0-9]+)/$', 'geojson_location_details', name='api_geojson_location_details'),
     url(r'^geojson/(?P<slug>[-\w]+)/$', 'geojson_location_slug_details', name='api_geojson_location_slug_details'),
     url(r'^geojson-falseid/(?P<pk>[0-9]+)/$', 'geojson_location_falseid_details', name='api_geojson_location_falseid_details'),
-    
+    url(r'^geojson-image/(?P<pk>[0-9]+)/$', 'geojson_located_image_details', name='api_geojson_located_image_details'),
+
     # Filters
     url(r'^filters/contained_in_bbox$', 'geojson_location_contained_in_bbox_list', name='api_geojson_location_list_contained_in_bbox_filter'),
     url(r'^filters/overlaps_bbox$', 'geojson_location_overlaps_bbox_list', name='api_geojson_location_list_overlaps_bbox_filter'),

--- a/tests/django_restframework_gis_tests/views.py
+++ b/tests/django_restframework_gis_tests/views.py
@@ -121,3 +121,11 @@ class GeojsonLocationContainedInGeometry(generics.ListAPIView):
     filter_backends = (DjangoFilterBackend,)
 
 geojson_contained_in_geometry = GeojsonLocationContainedInGeometry.as_view()
+
+class GeojsonLocatedImageDetails(generics.RetrieveUpdateDestroyAPIView):
+    model = LocatedImage
+    serializer_class = LocatedImageGeoFeatureSerializer
+    queryset = LocatedImage.objects.all()
+
+geojson_located_image_details = GeojsonLocatedImageDetails.as_view()
+

--- a/tests/django_restframework_gis_tests/views.py
+++ b/tests/django_restframework_gis_tests/views.py
@@ -122,6 +122,15 @@ class GeojsonLocationContainedInGeometry(generics.ListAPIView):
 
 geojson_contained_in_geometry = GeojsonLocationContainedInGeometry.as_view()
 
+
+class GeojsonLocatedFileDetails(generics.RetrieveUpdateDestroyAPIView):
+    model = LocatedFile
+    serializer_class = LocatedFileGeoFeatureSerializer
+    queryset = LocatedFile.objects.all()
+
+geojson_located_file_details = GeojsonLocatedFileDetails.as_view()
+
+
 class GeojsonLocatedImageDetails(generics.RetrieveUpdateDestroyAPIView):
     model = LocatedImage
     serializer_class = LocatedImageGeoFeatureSerializer


### PR DESCRIPTION
This is a really subtle weird error, but I was getting errors serializing an optional ImageField with no file associated with it--the errors kept insisting that there ought to be a file. I tried adding `allow_empty_file=True` and that works fine for GeoModelSerializer and the regular DRF ModelSerializer, but broke with GeoFeatureModelSerializer.

It turns out, in the GeoFeatureModelSerializer code, if I check _explicitly_ for whether the value is `None`, I can get GeoFeatureModelSerializer to work. My hunch is that ImageField, when empty, is a value that is equal to `None` (i.e. `<ImageFieldFile: None>`), but will not pass a merely "falsey" condition.  So I had to write it as;
`if value is not None:`
rather than
`if value:`

This is actually what DRF ModelSerializer itself does, more or less.
https://github.com/tomchristie/django-rest-framework/blob/master/rest_framework/serializers.py#L430