### PR TITLE
Fields will not read what it writes

### DIFF
--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -7,6 +7,11 @@ from django.utils.translation import ugettext_lazy as _
 from rest_framework.fields import Field
 
 
+class JSONDict(dict):
+    def __str__(self):
+        return json.dumps(self)
+
+
 class GeometryField(Field):
     """
     A field to handle GeoDjango Geometry fields
@@ -22,7 +27,7 @@ class GeometryField(Field):
             return value
         # Get GeoDjango geojson serialization and then convert it _back_ to
         # a Python object
-        return json.loads(GEOSGeometry(value).geojson)
+        return JSONDict(json.loads(GEOSGeometry(value).geojson))
 
     def to_internal_value(self, value):
         if value == '' or value is None:

--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -38,7 +38,7 @@ class GeometryField(Field):
         if isinstance(value, dict):
             value = json.dumps(value)
         try:
-            return GEOSGeometry(json.dumps(ast.literal_eval(value))).geojson
+            return GEOSGeometry(value).geojson
         except (ValueError, GEOSException, OGRException, TypeError):
             raise ValidationError(_('Invalid format: string or unicode input unrecognized as WKT EWKT, and HEXEWKB.'))
 

--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -1,5 +1,5 @@
 import json
-import ast
+
 from django.contrib.gis.geos import GEOSGeometry, GEOSException
 from django.contrib.gis.gdal import OGRException
 from django.core.exceptions import ValidationError

--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -1,5 +1,5 @@
 import json
-
+import ast
 from django.contrib.gis.geos import GEOSGeometry, GEOSException
 from django.contrib.gis.gdal import OGRException
 from django.core.exceptions import ValidationError
@@ -33,7 +33,7 @@ class GeometryField(Field):
         if isinstance(value, dict):
             value = json.dumps(value)
         try:
-            return GEOSGeometry(value).geojson
+            return GEOSGeometry(json.dumps(ast.literal_eval(value))).geojson
         except (ValueError, GEOSException, OGRException, TypeError):
             raise ValidationError(_('Invalid format: string or unicode input unrecognized as WKT EWKT, and HEXEWKB.'))
 


### PR DESCRIPTION
When to_representation is run on a geo object json.load adds unicode strings so the result is something like:

```
{u'type': u'Point', u'coordinates': [39.921092168090915, 28.04062843322754]}
```

this is the string that rest_framework puts into the web form for any PUTs to edit the field. Therefore the PUT will send the string:

```
"{u'type': u'Point', u'coordinates': [39.921092168090915, 28.04062843322754]}"
```

which will not work with GEOSGeometry as it does not expect the u symbols. The way around this is to eval the string as a python dictionary and then dump the json. This creates the string:

```
'{"type": "Point", "coordinates": [39.921092168090915, 28.04062843322754]}'
```

which will then work.