### PR TITLE
Django Rest Framework is now at 3.1.3.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-djangorestframework>=3.0.4,<=3.1.2
+djangorestframework>=3.0.4,<=3.1.3


### PR DESCRIPTION
Noticed the requirements were outdated.