### PR TITLE
allow None value for geometry

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -241,6 +241,8 @@ In this case you can compute its value during serialization. For example:
             model = Location
             geo_field = 'other_point'
 
+Serializer for ``geo_field`` may also return ``None`` value, which will translate to ``null`` value for geojson ``geometry`` field.
+
 Specifying the ID: "id_field"
 #############################
 

--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -49,7 +49,10 @@ class GeometryField(Field):
 class GeometrySerializerMethodField(SerializerMethodField):
     def to_representation(self, value):
         value = super(GeometrySerializerMethodField, self).to_representation(value)
-        return GeoJsonDict(value)
+        if value is not None:
+            return GeoJsonDict(value)
+        else:
+            return None
 
 
 class GeoJsonDict(OrderedDict):

--- a/tests/django_restframework_gis_tests/serializers.py
+++ b/tests/django_restframework_gis_tests/serializers.py
@@ -16,6 +16,7 @@ __all__ = [
     'BoxedLocationGeoFeatureSerializer',
     'LocationGeoFeatureBboxSerializer',
     'LocationGeoFeatureMethodSerializer',
+    'NoneGeoFeatureMethodSerializer',
 ]
 
 
@@ -103,6 +104,17 @@ class LocationGeoFeatureMethodSerializer(gis_serializers.GeoFeatureModelSerializ
             return Point(0., 0.)
         else:
             return obj.geometry
+
+    class Meta:
+        model = Location
+        geo_field = 'new_geometry'
+
+
+class NoneGeoFeatureMethodSerializer(gis_serializers.GeoFeatureModelSerializer):
+    new_geometry = gis_serializers.GeometrySerializerMethodField()
+
+    def get_new_geometry(self, obj):
+        return None
 
     class Meta:
         model = Location

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -495,6 +495,16 @@ class TestRestFrameworkGis(TestCase):
         self.assertEqual(response.data['geometry']['type'], 'Point')
         self.assertEqual(response.data['geometry']['coordinates'], (0.0, 0.0))
 
+    def test_geometry_serializer_method_field_none(self):
+        location = Location.objects.create(name='None value', geometry='POINT (135.0 45.0)')
+        location_loaded = Location.objects.get(pk=location.id)
+        self.assertEqual(location_loaded.geometry, Point(135.0, 45.0))
+        url = reverse('api_geojson_location_details_none', args=[location.id])
+        response = self.client.generic('GET', url, content_type='application/json')
+        self.assertEqual(response.status_code, 200)
+        self.assertEqual(response.data['properties']['name'], 'None value')
+        self.assertEqual(response.data['geometry'], None)
+
     def test_filterset(self):
         from rest_framework_gis.filterset import GeoFilterSet
 

--- a/tests/django_restframework_gis_tests/urls.py
+++ b/tests/django_restframework_gis_tests/urls.py
@@ -9,6 +9,7 @@ urlpatterns = patterns('django_restframework_gis_tests.views',
     url(r'^geojson/$', 'geojson_location_list', name='api_geojson_location_list'),
     url(r'^geojson/(?P<pk>[0-9]+)/$', 'geojson_location_details', name='api_geojson_location_details'),
     url(r'^geojson_hidden/(?P<pk>[0-9]+)/$', 'geojson_location_details_hidden', name='api_geojson_location_details_hidden'),
+    url(r'^geojson_none/(?P<pk>[0-9]+)/$', 'geojson_location_details_none', name='api_geojson_location_details_none'),
     url(r'^geojson/(?P<slug>[-\w]+)/$', 'geojson_location_slug_details', name='api_geojson_location_slug_details'),
     url(r'^geojson-falseid/(?P<pk>[0-9]+)/$', 'geojson_location_falseid_details', name='api_geojson_location_falseid_details'),
 

--- a/tests/django_restframework_gis_tests/views.py
+++ b/tests/django_restframework_gis_tests/views.py
@@ -99,6 +99,14 @@ class GeojsonLocationDetailsHidden(generics.RetrieveUpdateDestroyAPIView):
 geojson_location_details_hidden = GeojsonLocationDetailsHidden.as_view()
 
 
+class GeojsonLocationDetailsNone(generics.RetrieveUpdateDestroyAPIView):
+    model = Location
+    serializer_class = NoneGeoFeatureMethodSerializer
+    queryset = Location.objects.all()
+
+geojson_location_details_none = GeojsonLocationDetailsNone.as_view()
+
+
 class GeojsonLocationSlugDetails(generics.RetrieveUpdateDestroyAPIView):
     model = Location
     lookup_field = 'slug'


### PR DESCRIPTION
According to geojson spec `geometry` field may have `null` value
http://geojson.org/geojson-spec.html#geojson-objects

>A GeoJSON object with the type "Feature" is a feature object.

>A feature object must have a member with the name "geometry". The value of the geometry member is a geometry object as defined above or a JSON null value.

Corresponding Python value in the PR is set to be `None`, and it is allowed to be passed as value for `geo_field` from a serializer.
