### PR TITLE
fixed False or empty string values

### DIFF
--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -113,7 +113,7 @@ class GeoFeatureModelSerializer(ModelSerializer):
             value = field.get_attribute(instance)
             value_repr = None
 
-            if value:
+            if value is not None:
                 if field_name == self.Meta.bbox_geo_field:
                     # check for GEOSGeometry specfifc properties to generate the extent
                     # of the geometry.


### PR DESCRIPTION
If one of instance fields has a value of `False` or `''` (empty string) the serializer would translate those values to `None` which would in turn become `null` in json. This PR preserves correct field values.