### PR TITLE
Implement custom feature properties source

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -366,12 +366,12 @@ source for the `properties` field when rendering it to JSON.
 
 
 When the serializer renders GeoJSON, it calls the method
-`get_feature_properties` for each object in the database. This function
+``get_feature_properties`` for each object in the database. This function
 should return a dictionary containing the attributes for the feature. In the
 case of a HStore field, this function is easily implemented.
 
 The reverse is also required: mapping a GeoJSON formatted structure to
-attributes of your model. This task is done by `unformat_geojson`. It should
+attributes of your model. This task is done by ``unformat_geojson``. It should
 return a dictionary with your model attributes as keys, and the corresponding
 values retrieved from the GeoJSON feature data.
 

--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -132,8 +132,7 @@ class GeoFeatureModelSerializer(ModelSerializer):
 
             if not field.write_only:
                 value = field.get_attribute(instance)
-                ret["bbox"] = (value.extent if hasattr(value, 'extent') else
-                               None)
+                ret["bbox"] = value.extent if hasattr(value, 'extent') else None
 
         ret["properties"] = self.get_feature_properties(instance)
 
@@ -149,8 +148,7 @@ class GeoFeatureModelSerializer(ModelSerializer):
         else:
             _unformatted_data = data
 
-        return super(GeoFeatureModelSerializer, self).to_internal_value(
-            _unformatted_data)
+        return super(GeoFeatureModelSerializer, self).to_internal_value(_unformatted_data)
 
     def get_feature_properties(self, instance):
         """
@@ -201,8 +199,7 @@ class GeoFeatureModelSerializer(ModelSerializer):
             attribs[self.Meta.geo_field] = feature['geometry']
 
         if self.Meta.bbox_geo_field and 'bbox' in feature:
-            attribs[self.Meta.bbox_geo_field] = Polygon.from_bbox(
-                feature['bbox'])
+            attribs[self.Meta.bbox_geo_field] = Polygon.from_bbox(feature['bbox'])
 
         return attribs
 

--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -107,52 +107,103 @@ class GeoFeatureModelSerializer(ModelSerializer):
         if self.Meta.bbox_geo_field or self.Meta.auto_bbox:
             ret["bbox"] = None
 
-        for field in self.fields.values():
-            if field.write_only:
-                continue
+        id_field = self.Meta.id_field
+        geo_field = self.Meta.geo_field
+        bbox_field = self.Meta.bbox_geo_field
+        if id_field is not False and id_field in self.fields:
+            field = self.fields[id_field]
 
-            field_name = field.field_name
-            value = field.get_attribute(instance)
-            value_repr = None
+            if not field.write_only:
+                value = field.get_attribute(instance)
+                ret["id"] = field.to_representation(value)
 
-            if value is not None:
-                if field_name == self.Meta.bbox_geo_field:
-                    # check for GEOSGeometry specfifc properties to generate the extent
-                    # of the geometry.
-                    if hasattr(value, 'extent'):
-                        value_repr = value.extent
-                else:
-                    value_repr = field.to_representation(value)
+        if geo_field in self.fields:
+            field = self.fields[geo_field]
 
-            if self.Meta.id_field is not False and field_name == self.Meta.id_field:
-                ret["id"] = value_repr
-            elif field_name == self.Meta.geo_field:
-                ret["geometry"] = value_repr
+            if not field.write_only:
+                value = field.get_attribute(instance)
+                ret["geometry"] = field.to_representation(value)
+
                 if self.Meta.auto_bbox and value:
-                    ret['bbox'] = value.extent
-            elif field_name == self.Meta.bbox_geo_field:
-                ret["bbox"] = value_repr
-            elif not getattr(field, 'write_only', False):
-                ret["properties"][field_name] = value_repr
+                    ret["bbox"] = value.extent
+
+        if bbox_field in self.fields:
+            field = self.fields[bbox_field]
+
+            if not field.write_only:
+                value = field.get_attribute(instance)
+                ret["bbox"] = (value.extent if hasattr(value, 'extent') else
+                               None)
+
+        ret["properties"] = self.get_feature_properties(instance)
+
         return ret
 
     def to_internal_value(self, data):
         """
         Override the parent method to first remove the GeoJSON formatting
         """
-        def make_unformated_data(feature):
-            _dict = feature["properties"]
-            if 'geometry' in feature:
-                geom = {self.Meta.geo_field: feature["geometry"]}
-                _dict.update(geom)
-            if self.Meta.bbox_geo_field and 'bbox' in feature:
-                # build a polygon from the bbox
-                _dict.update({self.Meta.bbox_geo_field: Polygon.from_bbox(feature['bbox'])})
-            return _dict
 
         if 'properties' in data:
-            _unformatted_data = make_unformated_data(data)
+            _unformatted_data = self.unformat_geojson(data)
         else:
             _unformatted_data = data
 
-        return super(GeoFeatureModelSerializer, self).to_internal_value(_unformatted_data)
+        return super(GeoFeatureModelSerializer, self).to_internal_value(
+            _unformatted_data)
+
+    def get_feature_properties(self, instance):
+        """
+        Get the feature metadata which will be used for the GeoJSON
+        "properties" key.
+
+        By default it returns all serializer fields excluding those used for
+        the ID, the geometry and the bounding box.
+
+        :param instance: The current Django model instance
+        :return: OrderedDict containing the properties of the current feature
+        :rtype: OrderedDict
+        """
+        exclude = [
+            field_name for field_name in (self.Meta.id_field,
+                                          self.Meta.geo_field,
+                                          self.Meta.bbox_geo_field)
+            if field_name
+        ]
+        properties = OrderedDict()
+
+        for field in self.fields.values():
+            if field.write_only or field.field_name in exclude:
+                continue
+
+            value = field.get_attribute(instance)
+            properties[field.field_name] = field.to_representation(value)
+
+        return properties
+
+    def unformat_geojson(self, feature):
+        """
+        This function should return a dictionary containing keys which maps
+        to serializer fields.
+
+        Remember that GeoJSON contains a key "properties" which contains the
+        feature metadata. This should be flattened to make sure this
+        metadata is stored in the right serializer fields.
+
+        :param feature: The dictionary containing the feature data directly
+                        from the GeoJSON data.
+        :return: A new dictionary which maps the GeoJSON values to
+                 serializer fields
+        """
+        attribs = feature["properties"]
+
+        if 'geometry' in feature:
+            attribs[self.Meta.geo_field] = feature['geometry']
+
+        if self.Meta.bbox_geo_field and 'bbox' in feature:
+            attribs[self.Meta.bbox_geo_field] = Polygon.from_bbox(
+                feature['bbox'])
+
+        return attribs
+
+


### PR DESCRIPTION
By default, when converting a django model instance with geometry
to GeoJSON, the "properties" field will be filled with the fields
defined in the corresponding serializer.

In this PR we separate the code a bit in individual methods,
which can be overridden by any subclass. In this way the user is
able to define their own source for the properties field of the
GeoJSON output.

Solves #70 