### PR TITLE
Return GEOSGeometry instead of geojson property

### DIFF
--- a/rest_framework_gis/fields.py
+++ b/rest_framework_gis/fields.py
@@ -36,7 +36,7 @@ class GeometryField(Field):
         if isinstance(value, dict):
             value = json.dumps(value)
         try:
-            return GEOSGeometry(value).geojson
+            return GEOSGeometry(value)
         except (ValueError, GEOSException, OGRException, TypeError):
             raise ValidationError(_('Invalid format: string or unicode input unrecognized as GeoJSON, WKT EWKT or HEXEWKB.'))
 

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -122,6 +122,21 @@ class TestRestFrameworkGis(TestCase):
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
 
+    def test_post_location_list_EWKT(self):
+        self.assertEqual(Location.objects.count(), 0)
+        data = {
+            'name': 'EWKT input test',
+            'geometry': 'SRID=28992;POINT(221160 600204)'
+        }
+        response = self.client.post(self.location_list_url, data)
+        expected_coords = (6.381495826183805, 53.384066927384985)
+        self.assertEqual(response.status_code, 201)
+        self.assertEqual(Location.objects.count(), 1)
+        self.assertEquals(
+            Location.objects.get(name='EWKT input test').geometry.coords,
+            expected_coords
+        )
+
     def test_post_location_list_WKT_as_json(self):
         self.assertEqual(Location.objects.count(), 0)
         data = {


### PR DESCRIPTION
Return GEOSGeometry instead of geojson property of GEOSGeometry to_internal_value() method of GeometryField.

Fixes https://github.com/djangonauts/django-rest-framework-gis/issues/74