### PR TITLE
Assert that the coordinates are approximately equal instead of absolu…

### DIFF
--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -132,10 +132,8 @@ class TestRestFrameworkGis(TestCase):
         expected_coords = (6.381495826183805, 53.384066927384985)
         self.assertEqual(response.status_code, 201)
         self.assertEqual(Location.objects.count(), 1)
-        self.assertEquals(
-            Location.objects.get(name='EWKT input test').geometry.coords,
-            expected_coords
-        )
+        for l, e in zip(Location.objects.get(name='EWKT input test').geometry.coords, expected_coords):
+            self.assertAlmostEqual(l, e, places=5)
 
     def test_post_location_list_WKT_as_json(self):
         self.assertEqual(Location.objects.count(), 0)


### PR DESCRIPTION
…tely equal.

This is necessary because spatialite, which is used by the unittests in the
Debian package, yields a lower precision when it comes to floating point
coordinates compared to PostgreSQL. This should fix #83.