### PR TITLE
Fix serialization of properties holding None values

### DIFF
--- a/rest_framework_gis/serializers.py
+++ b/rest_framework_gis/serializers.py
@@ -151,7 +151,10 @@ class GeoFeatureModelSerializer(ModelSerializer):
             if field.write_only:
                 continue
             value = field.get_attribute(instance)
-            properties[field.field_name] = field.to_representation(value)
+            value_repr = None
+            if value is not None:
+                value_repr = field.to_representation(value)
+            properties[field.field_name] = value_repr
 
         return properties
 

--- a/tests/django_restframework_gis_tests/models.py
+++ b/tests/django_restframework_gis_tests/models.py
@@ -12,6 +12,7 @@ __all__ = [
 class BaseModel(models.Model):
     name = models.CharField(max_length=32)
     slug = models.SlugField(max_length=128, unique=True, blank=True)
+    timestamp = models.DateTimeField(null=True, blank=True)
     geometry = models.GeometryField()
     objects = models.GeoManager()
 

--- a/tests/django_restframework_gis_tests/serializers.py
+++ b/tests/django_restframework_gis_tests/serializers.py
@@ -54,7 +54,7 @@ class LocationGeoFeatureSlugSerializer(LocationGeoFeatureSerializer):
         model = Location
         geo_field = 'geometry'
         id_field = 'slug'
-        fields = ('name', 'slug')
+        fields = ('name', 'slug', 'timestamp')
 
 
 class LocationGeoFeatureFalseIdSerializer(LocationGeoFeatureSerializer):
@@ -98,7 +98,7 @@ class BoxedLocationGeoFeatureSerializer(gis_serializers.GeoFeatureModelSerialize
         model = BoxedLocation
         geo_field = 'geometry'
         bbox_geo_field = 'bbox_geometry'
-        fields = ['name', 'details', 'id']
+        fields = ['name', 'details', 'id', 'timestamp']
 
 
 class LocationGeoFeatureBboxSerializer(gis_serializers.GeoFeatureModelSerializer):

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -228,6 +228,7 @@ class TestRestFrameworkGis(TestCase):
                 'details': "http://testserver/geojson/%s/" % location.id,
                 'name': 'geojson test',
                 'fancy_name': 'Kool geojson test',
+                'timestamp': None,
                 'slug': 'geojson-test',
             },
             'geometry': {


### PR DESCRIPTION
The current implementation fails to serialize properties holding the value None. This may not affect al types of field as it depends how the field handles its conversion in its Field.to_representation() method. At least with datetime fields the attempt to serialize a None value will result in an AttributeError -- see the following stacktrace:

      [...]
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 466, in data
        ret = super(Serializer, self).data
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 213, in data
        self._data = self.to_representation(self.instance)
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 435, in to_representation
        ret[field.field_name] = field.to_representation(attribute)
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework_gis/serializers.py", line 27, in to_representation
        ("features", super(GeoFeatureModelListSerializer, self).to_representation(data))
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework/serializers.py", line 568, in to_representation
        self.child.to_representation(item) for item in iterable
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework_gis/serializers.py", line 125, in to_representation
        feature["properties"] = self.get_properties(instance, fields)
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework_gis/serializers.py", line 148, in get_properties
        properties[field.field_name] = field.to_representation(value)
      File "/home/nico/environments/venv-django17/local/lib/python2.7/site-packages/rest_framework/fields.py", line 883, in to_representation
        return value.strftime(self.format)
    AttributeError: 'NoneType' object has no attribute 'strftime'

This pull request addresses this issue by calling the to_representation method only when there is an actual value to convert.