### PR TITLE
Include assets in source tarball

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,7 @@
-include AUTHORS LICENSE README.rst CHANGES.rst requirements.txt runtests.py
-recursive-include tests *
-recursive-exclude * *.pyc *.swp
+include AUTHORS
+include LICENSE
+include README.rst
+include CHANGES.rst
+include requirements.txt
+include runtests.py
+recursive-include tests *.py

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include AUTHORS LICENSE README.rst requirements.txt
+include AUTHORS LICENSE README.rst CHANGES.rst requirements.txt runtests.py
 recursive-include tests *
 recursive-exclude * *.pyc *.swp


### PR DESCRIPTION
This adds `CHANGES.rst` and `runtests.py` to the source tarball to make the pypi tarball usable for Debian packaging. It also cleans up the entries in MANIFEST.in for better readability, refines the `recursive-include`for tests and removes the `recursive-excludes` entry as it should not have any effect on the resulting tarball (only explicit includes present).