### PR TITLE
README: fix example

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -341,7 +341,7 @@ the ``properties`` member:
         Metadata is stored in a PostgreSQL HStore field, which allows us to
         store arbitrary key-value pairs with a link record.
         """
-        metadata = HStoreField(blank=True, null=True, default={})
+        metadata = HStoreField(blank=True, null=True, default=dict)
         geo = models.LineStringField()
         objects = models.GeoManager()
 


### PR DESCRIPTION
The Django docs gives the following warning for `JSONField` (should be valid for `HStoreField` as well):

> If you give the field a default, ensure it’s a callable such as dict (for an empty default) or a callable that returns a dict (such as a function). Incorrectly using default={} creates a mutable default that is shared between all instances of JSONField.

Fixes #107.