### PR TITLE
Corrected wrong bounding box params in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -483,8 +483,8 @@ a certain bounding box.
         filter_backends = (InBBoxFilter, )
         bbox_filter_include_overlapping = True # Optional
 
-We can then filter in the URL, using Bounding Box format (min Lon, min
-Lat, max Lon, max Lat), and we can search for instances within the
+We can then filter in the URL, using Bounding Box format (min Lat, min
+Lon, max Lat, max Lon), and we can search for instances within the
 bounding box, e.g.:
 ``/location/?in_bbox=-90,29,-89,35``.
 


### PR DESCRIPTION
Hi! I think I found a typo in the order of the params in "in_bbox" param. When integrating the plugin, I found that it only works if the order is lon, lat (instead of lat, lon). I've also looked at the code and I think that the proper order is lon, lat.

Thank you very much for your plugin!! Very simple to use and very well documented ^_^