### PR TITLE
Add support for GeometryCollection fields

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,3 +1,4 @@
+six
 psycopg2
 djangorestframework>=3.3
 coverage==3.7.1  # rq.filter: >=3,<4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
+six
 djangorestframework>=3.3,<3.7


### PR DESCRIPTION
Fixes #126 
We have a project that has a need to support GeometryCollection fields.  After poking around I decided to try altering the GeometryField and GeometrySerializerMethodField to use GeoDjango's built-in geojson output instead of creating a GeoJSON object on the fly.  It seems to be a small change and fixes the issue in our project without breaking elsewhere.