### PR TITLE
Fixes for test_geojson_performance with DRF >=3.5

### DIFF
--- a/tests/django_restframework_gis_tests/test_performance.py
+++ b/tests/django_restframework_gis_tests/test_performance.py
@@ -34,6 +34,7 @@ if 'django_restframework_gis_tests.test_performance' in sys.argv or settings.TES
                 class Meta:
                     model = Location
                     geo_field = 'geometry'
+                    fields = '__all__'
             # create data
             self._create_data()
             # initialize serializer


### PR DESCRIPTION
The test_geojson_performance test was failing an assertion in DRF>=3.5   Fixed by adding fields='__all__' to the PerfSerializer class.