### PR TITLE
[QA] Change django-filter test requirement to latest

### DIFF
--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -3,5 +3,5 @@ psycopg2
 djangorestframework>=3.3
 coverage==3.7.1  # rq.filter: >=3,<4
 coveralls
-django-filter>=0.15,<1.1
+django-filter>=0.15,<1.2
 contexttimer


### PR DESCRIPTION
This change didn't seem to cause any issues in Travis testing.

Do we want to cap it at 1.1.0 or allow it to go up as django-filter is updated?

Fixes #148.
