### PR TITLE
removing every reference of olwidget & making admin widget as default geodjango widget.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -604,9 +604,7 @@ contributing to the project:
    ``cp local_settings.example.py local_settings.py``
 -  tweak the ``DATABASES`` configuration directive according to your DB
    settings
--  optionally install ``olwidget`` with ``pip install olwidget``
--  uncomment ``INSTALLED_APPS`` (remove olwidget if you did not install
-   it)
+-  uncomment ``INSTALLED_APPS``
 -  run ``python manage.py syncdb``
 -  run ``python manage.py collectstatic``
 -  run ``python manage.py runserver``

--- a/tests/django_restframework_gis_tests/admin.py
+++ b/tests/django_restframework_gis_tests/admin.py
@@ -1,12 +1,7 @@
 from django.contrib import admin
 from django.conf import settings
 
-GEODJANGO_IMPROVED_WIDGETS = 'olwidget' in settings.INSTALLED_APPS
-
-if GEODJANGO_IMPROVED_WIDGETS:
-    from olwidget.admin import GeoModelAdmin
-else:
-    from django.contrib.gis.admin import ModelAdmin as GeoModelAdmin
+from django.contrib.gis.admin import ModelAdmin as GeoModelAdmin
 
 from .models import Location
 

--- a/tests/local_settings.example.py
+++ b/tests/local_settings.example.py
@@ -23,8 +23,6 @@ TEST_PERFORMANCE = True
 #    'django.contrib.gis',
 #
 #    # geodjango widgets
-#    'olwidget',
-#
 #    # admin
 #    #'grappelli',
 #    'django.contrib.admin',


### PR DESCRIPTION
Removing every reference of olwidget & making admin widget as default geodjango widget as olwidget is no longer used. All reference from test suite were removed and in place of that, admin widget is made default. Also, olwidget reference in README is also removed. This is part of a Google code-in task: https://codein.withgoogle.com/tasks/5187389683138560/?sp-organization=5693741010518016.

This also closes task #133
