### PR TITLE
Fix default widget for GeometryFilter

### DIFF
--- a/rest_framework_gis/filters.py
+++ b/rest_framework_gis/filters.py
@@ -81,7 +81,7 @@ class GeometryFilter(django_filters.Filter):
     field_class = forms.GeometryField
 
     def __init__(self, *args, **kwargs):
-        kwargs.setdefault('widget', forms.BaseGeometryWidget)
+        kwargs.setdefault('widget', forms.TextInput)
         super(GeometryFilter, self).__init__(*args, **kwargs)
 
 


### PR DESCRIPTION
Using `forms.BaseGeometryWidget` will cause a IsADirectoryError, because
of an empty template_name being used.
This was added by me in eb54fc0.

This patch changes it to use a simple TextInput; I can imagine using a
nicer widget here, but that requires to also add/handle the required
media assets, which was not trivial (IIRC).

```
Template error:
In template …/project/.venv/lib/python3.6/site-packages/django_filters/templates/django_filters/rest_framework/form.html, error at line 4
   21
   1 : {% load i18n %}
   2 : <h2>{% trans "Field filters" %}</h2>
   3 : <form class="form" action="" method="get">
   4 :      {{ filter.form.as_p }}
   5 :     <button type="submit" class="btn btn-primary">{% trans "Submit" %}</button>
   6 : </form>
   7 :

Traceback:

File "…/Vcs/django/django/core/handlers/exception.py" in inner
  35.             response = get_response(request)

File "…/Vcs/django/django/core/handlers/base.py" in _get_response
  158.                 response = self.process_exception_by_middleware(e, request)

File "…/Vcs/django/django/core/handlers/base.py" in _get_response
  156.                 response = response.render()

File "…/Vcs/django/django/template/response.py" in render
  106.             self.content = self.rendered_content

File "…/Vcs/django-rest-framework/rest_framework/response.py" in rendered_content
  72.         ret = renderer.render(self.data, accepted_media_type, context)

File "…/Vcs/django-rest-framework/rest_framework/renderers.py" in render
  724.         context = self.get_context(data, accepted_media_type, renderer_context)

File "…/Vcs/django-rest-framework/rest_framework/renderers.py" in get_context
  701.             'filter_form': self.get_filter_form(data, view, request),

File "…/Vcs/django-rest-framework/rest_framework/renderers.py" in get_filter_form
  635.                 html = backend().to_html(request, queryset, view)

File "…/project/.venv/lib/python3.6/site-packages/django_filters/rest_framework/backends.py" in to_html
  69.         return template.render(context, request)

File "…/Vcs/django/django/template/backends/django.py" in render
  61.             return self.template.render(context)

File "…/Vcs/django/django/template/base.py" in render
  175.                     return self._render(context)

File "…/Vcs/django/django/test/utils.py" in instrumented_test_render
  98.     return self.nodelist.render(context)

File "…/Vcs/django/django/template/base.py" in render
  943.                 bit = node.render_annotated(context)

File "…/Vcs/django/django/template/base.py" in render_annotated
  910.             return self.render(context)

File "…/Vcs/django/django/template/base.py" in render
  993.             output = self.filter_expression.resolve(context)

File "…/Vcs/django/django/template/base.py" in resolve
  676.                 obj = self.var.resolve(context)

File "…/Vcs/django/django/template/base.py" in resolve
  802.             value = self._resolve_lookup(context)

File "…/Vcs/django/django/template/base.py" in _resolve_lookup
  864.                             current = current()

File "…/Vcs/django/django/forms/forms.py" in as_p
  297.             errors_on_separate_row=True)

File "…/Vcs/django/django/forms/forms.py" in _html_output
  238.                     'field_name': bf.html_name,

File "…/Vcs/django/django/utils/html.py" in <lambda>
  371.     klass.__str__ = lambda self: mark_safe(klass_str(self))

File "…/Vcs/django/django/forms/boundfield.py" in __str__
  36.         return self.as_widget()

File "…/Vcs/django/django/forms/boundfield.py" in as_widget
  118.             **kwargs

File "…/Vcs/django/django/forms/widgets.py" in render
  235.         return self._render(self.template_name, context, renderer)

File "…/Vcs/django/django/forms/widgets.py" in _render
  240.         return mark_safe(renderer.render(template_name, context))

File "…/Vcs/django/django/forms/renderers.py" in render
  30.         template = self.get_template(template_name)

File "…/Vcs/django/django/forms/renderers.py" in get_template
  36.         return self.engine.get_template(template_name)

File "…/Vcs/django/django/template/backends/django.py" in get_template
  34.             return Template(self.engine.get_template(template_name), self)

File "…/Vcs/django/django/template/engine.py" in get_template
  144.         template, origin = self.find_template(template_name)

File "…/Vcs/django/django/template/engine.py" in find_template
  126.                 template = loader.get_template(name, skip=skip)

File "…/Vcs/django/django/template/loaders/base.py" in get_template
  24.                 contents = self.get_contents(origin)

File "…/Vcs/django/django/template/loaders/filesystem.py" in get_contents
  23.             with open(origin.name, encoding=self.engine.file_charset) as fp:

Exception Type: IsADirectoryError at /api/foo/
Exception Value: [Errno 21] Is a directory: '…/Vcs/django/django/forms/templates'
```