### PR TITLE
Support django 2.1, DRF 3.9 and use django-filters > 2.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,27 @@ matrix:
       python: 3.5
     - env: TOXENV=py36-django20
       python: 3.6
+    # https://github.com/travis-ci/travis-ci/issues/9815
     - env: TOXENV=py37-django20
       python: 3.7
       dist: xenial
-      sudo: required
+      sudo: true
+      addons:
+        postgresql: "9.4"
+        apt:
+            packages:
+            - postgresql-9.4-postgis-2.4
+      services:
+        - postgresql
+    - env: TOXENV=py35-django21
+      python: 3.5
+    - env: TOXENV=py36-django21
+      python: 3.6
+    # https://github.com/travis-ci/travis-ci/issues/9815
+    - env: TOXENV=py37-django21
+      python: 3.7
+      dist: xenial
+      sudo: true
       addons:
         postgresql: "9.4"
         apt:

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,8 +12,6 @@ services:
 
 matrix:
   include:
-    - env: TOXENV=py27-django111
-      python: 2.7
     - env: TOXENV=py34-django111
       python: 3.4
     - env: TOXENV=py35-django111
@@ -28,6 +26,15 @@ matrix:
       python: 3.6
     - env: TOXENV=py37-django20
       python: 3.7
+      dist: xenial
+      sudo: required
+      addons:
+        postgresql: "9.4"
+        apt:
+            packages:
+            - postgresql-9.4-postgis-2.4
+      services:
+        - postgresql
 
 branches:
   only:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,6 +26,8 @@ matrix:
       python: 3.5
     - env: TOXENV=py36-django20
       python: 3.6
+    - env: TOXENV=py37-django20
+      python: 3.7
 
 branches:
   only:

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,26 @@
+FROM python:3.7-alpine3.8
+
+# postgresql-client is required by psql
+# postgresql-dev musl-dev gcc are required by psycopg
+# NOTE: there is py3-psycopg2
+# gdal-dev geos-dev proj4-dev are required by geodjango
+# NOTE: we actually need gdal-dev not gdal
+
+# TODO: optimize installation by using --virtual
+RUN apk update && apk upgrade \
+    && apk add postgresql-client postgresql-dev musl-dev gcc \
+    && apk add --repository http://dl-cdn.alpinelinux.org/alpine/edge/testing \
+        gdal-dev \
+        geos-dev \
+        proj4-dev
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONIOENCODING=UTF-8
+
+WORKDIR /project
+
+RUN pip install django
+
+COPY requirements-test.txt /project/
+
+RUN pip install -r requirements-test.txt

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,8 +7,6 @@ services:
         build:
             context: .
             dockerfile: Dockerfile
-        ports:
-            - "8000:8000"
         depends_on:
             - postgres
         volumes:
@@ -21,7 +19,6 @@ services:
     postgres:
         image: mdillon/postgis:10-alpine
         volumes:
-            - ./docker/postgres/:/docker-entrypoint-initdb.d/
             - postgres_data:/var/lib/postgresql/data
 
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,30 @@
+version: "3.7"
+
+
+services:
+
+    backend:
+        build:
+            context: .
+            dockerfile: Dockerfile
+        ports:
+            - "8000:8000"
+        depends_on:
+            - postgres
+        volumes:
+            - root_dir:/root
+            - ./rest_framework_gis:/project/rest_framework_gis
+            - ./tests:/project/tests
+            - ./runtests.py:/project/runtests.py
+        command: ["./runtests.py"]
+
+    postgres:
+        image: mdillon/postgis:10-alpine
+        volumes:
+            - ./docker/postgres/:/docker-entrypoint-initdb.d/
+            - postgres_data:/var/lib/postgresql/data
+
+
+volumes:
+    postgres_data:
+    root_dir:

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -1,5 +1,5 @@
 psycopg2
 coverage==3.7.1  # rq.filter: >=3,<4
 coveralls
-django-filter>=0.15,<1.2
+django-filter>=2.0
 contexttimer

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,1 @@
-djangorestframework>=3.3,<3.9
+djangorestframework>=3.3,<3.10

--- a/tests/django_restframework_gis_tests/tests.py
+++ b/tests/django_restframework_gis_tests/tests.py
@@ -487,7 +487,7 @@ class TestRestFrameworkGis(TestCase):
         self.assertContains(response, '"coordinates": [')
 
     @skipIf(not is_pre_drf_39, 'Skip this test if DRF >= 3.9')
-    def test_geojson_HTML_widget_value(self):
+    def test_geojson_HTML_widget_value_pre_drf_39(self):
         self._create_locations()
         response = self.client.get(self.geojson_location_list_url, HTTP_ACCEPT='text/html')
         self.assertContains(response, '<textarea name="geometry"')

--- a/tests/django_restframework_gis_tests/views.py
+++ b/tests/django_restframework_gis_tests/views.py
@@ -132,7 +132,7 @@ geojson_location_noid_details = GeojsonLocationNoIdDetails.as_view()
 
 
 class LocationFilter(GeoFilterSet):
-    contains_properly = GeometryFilter(name='geometry',
+    contains_properly = GeometryFilter(field_name='geometry',
                                        lookup_expr='contains_properly')
 
     class Meta:

--- a/tox.ini
+++ b/tox.ini
@@ -2,6 +2,7 @@
 envlist =
     py{34,35,36,py3}-django111{,-pytest}
     py{34,35,36,37,py3}-django20{,-pytest}
+    py{35,36,37,py3}-django21{,-pytest}
 
 [testenv]
 usedevelop = true
@@ -16,7 +17,8 @@ commands =
 
 deps =
     django111: Django>=1.11,<2.0
-    django20: Django>=2.0
+    django20: Django>=2.0,<2.1
+    django21: Django>=2.1,<2.2
     -rrequirements-test.txt
     pytest: pytest
     pytest: pytest-django

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{27,34,35,36,py,py3}-django111{,-pytest}
+    py{34,35,36,py3}-django111{,-pytest}
     py{34,35,36,37,py3}-django20{,-pytest}
 
 [testenv]

--- a/tox.ini
+++ b/tox.ini
@@ -1,7 +1,7 @@
 [tox]
 envlist =
     py{27,34,35,36,py,py3}-django111{,-pytest}
-    py{34,35,36,py3}-django20{,-pytest}
+    py{34,35,36,37,py3}-django20{,-pytest}
 
 [testenv]
 usedevelop = true
@@ -16,7 +16,7 @@ commands =
 
 deps =
     django111: Django>=1.11,<2.0
-    django20: Django>=2.0,<2.1
+    django20: Django>=2.0
     -rrequirements-test.txt
     pytest: pytest
     pytest: pytest-django


### PR DESCRIPTION
- Added python 3.7 to travis and tox
- removed python2  from travis and tox
- Had to update postgres for travis to 9.4 and postgis to 2.4 because django 2.1 dropped support for 9.3

also fixes #170 

Fails on python 2. Looks like I need to fix #171 as well. Can someone guide me so that I can drop python 2 support. What should be done I see multiple comments like 
```
class GeoJsonDict(OrderedDict):
    """
    Used for serializing GIS values to GeoJSON values
    TODO: remove this when support for python 2.6/2.7 will be dropped
    """
```

Should `GeoJsonDict` be removed? 