### PR TITLE
Bump DRF version bound to include 3.9

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,2 @@
 six
-djangorestframework>=3.3,<3.9
+djangorestframework>=3.3,<3.10


### PR DESCRIPTION
DRF 3.9 should already be compatible with drf-gis.