### PR TITLE
Added long description and additional urls in setup module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -16,6 +16,11 @@ if sys.argv[-1] == 'publish':
     sys.exit()
 
 
+# Get the long description from the README file
+with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+    long_description = f.read()
+
+
 setup(
     name='djangorestframework-gis',
     version=get_version(),
@@ -23,6 +28,7 @@ setup(
     author='Douglas Meehan',
     author_email='django-rest-framework-gis@googlegroups.com',
     description='Geographic add-ons for Django Rest Framework',
+    long_description=long_description,
     url='https://github.com/djangonauts/django-rest-framework-gis',
     download_url='https://github.com/djangonauts/django-rest-framework-gis/releases',
     platforms=['Platform Indipendent'],
@@ -46,5 +52,12 @@ setup(
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
         'Programming Language :: Python :: 3 :: Only',
-    ]
+    ],
+    project_urls={
+        'Bug Reports': 'https://github.com/djangonauts/django-rest-framework-gis/issues',
+        'Continuous Integration': 'https://travis-ci.org/djangonauts/django-rest-framework-gis',
+        'Mailing List': 'https://groups.google.com/forum/#!forum/django-rest-framework-gis',
+        'Code Coverage': 'https://coveralls.io/github/djangonauts/django-rest-framework-gis'
+        'Source Code': 'https://github.com/pypa/sampleproject/',
+    },
 )

--- a/setup.py
+++ b/setup.py
@@ -1,9 +1,10 @@
 #!/usr/bin/env python
-import sys
 import os
-from setuptools import setup, find_packages
-from rest_framework_gis import get_version
+import sys
 
+from setuptools import find_packages, setup
+
+from rest_framework_gis import get_version
 
 if sys.argv[-1] == 'publish':
     os.system("python setup.py sdist bdist_wheel")
@@ -15,9 +16,10 @@ if sys.argv[-1] == 'publish':
     print("  git push --tags")
     sys.exit()
 
+here = os.path.abspath(os.path.dirname(__file__))
 
 # Get the long description from the README file
-with open(path.join(here, 'README.rst'), encoding='utf-8') as f:
+with open(os.path.join(here, 'README.rst'), encoding='utf-8') as f:
     long_description = f.read()
 
 
@@ -57,7 +59,7 @@ setup(
         'Bug Reports': 'https://github.com/djangonauts/django-rest-framework-gis/issues',
         'Continuous Integration': 'https://travis-ci.org/djangonauts/django-rest-framework-gis',
         'Mailing List': 'https://groups.google.com/forum/#!forum/django-rest-framework-gis',
-        'Code Coverage': 'https://coveralls.io/github/djangonauts/django-rest-framework-gis'
+        'Code Coverage': 'https://coveralls.io/github/djangonauts/django-rest-framework-gis',
         'Source Code': 'https://github.com/pypa/sampleproject/',
     },
 )

--- a/setup.py
+++ b/setup.py
@@ -60,6 +60,6 @@ setup(
         'Continuous Integration': 'https://travis-ci.org/djangonauts/django-rest-framework-gis',
         'Mailing List': 'https://groups.google.com/forum/#!forum/django-rest-framework-gis',
         'Code Coverage': 'https://coveralls.io/github/djangonauts/django-rest-framework-gis',
-        'Source Code': 'https://github.com/pypa/sampleproject/',
+        'Source Code': 'https://github.com/djangonauts/django-rest-framework-gis',
     },
 )


### PR DESCRIPTION
I've created this PR to show the README and useful links in the PyPi packages page, removing the message "The author of this package has not provided a project description":
https://pypi.org/project/djangorestframework-gis/