### PR TITLE
Fixed README invalid markup that cause PyPI to show the raw source.

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -661,6 +661,7 @@ tests manually / without tox.
 To run tests in docker use
 
 .. code-block:: bash
+
     docker-compose build
     docker-compose run --rm test
 


### PR DESCRIPTION
After last release the README is visible in on pypi.org but as raw code.
https://pypi.org/project/djangorestframework-gis/

I checked the README.rst file and found this error:
```bash
$ python setup.py check -r -s
running check
warning: check: Error in "code-block" directive:
maximum 1 argument(s) allowed, 7 supplied. (line 663)
error: Please correct your package.
```
I fixed the README.rst and checked again to confirm it's validity.

For the next release could be useful check the package before submit it:
https://packaging.python.org/guides/making-a-pypi-friendly-readme/#validating-restructuredtext-markup